### PR TITLE
Fix a spelling error in ext-postgres/database

### DIFF
--- a/charts/postgres/ext-postgres/database/templates/database.yml
+++ b/charts/postgres/ext-postgres/database/templates/database.yml
@@ -38,7 +38,7 @@ apiVersion: db.movetokube.com/v1alpha1
 kind: PostgresUser
 metadata:
   name: {{ .Values.database }}-ro
-  namespace: db-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   role: {{ .Values.username }}
   database: {{ .Values.database }}


### PR DESCRIPTION
It's minor spelling error, but it prevents it from being installed.