### PR TITLE
Remove extraneous 'name' for 'accessKeyId'

### DIFF
--- a/charts/postgres/cluster/v0.0.1/templates/cluster.yaml
+++ b/charts/postgres/cluster/v0.0.1/templates/cluster.yaml
@@ -27,7 +27,6 @@ spec:
       s3Credentials:
         accessKeyId:
           name: {{ .Release.Name }}-s3
-          name: contabocredentials
           key: username
         secretAccessKey:
           name: {{ .Release.Name }}-s3


### PR DESCRIPTION
It seems and extra value for the key snuck in at some point.