### PR TITLE
feat: add zitadel configurator 0.0.1

### DIFF
--- a/charts/auth/dex-k8s-authenticator/0.0.3/values.yaml
+++ b/charts/auth/dex-k8s-authenticator/0.0.3/values.yaml
@@ -172,11 +172,3 @@ secret:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "0"
-
-rbac:
-  create: true
-  namePrefix: dex
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"

--- a/charts/auth/zitadel-configurator/0.0.1/Chart.yaml
+++ b/charts/auth/zitadel-configurator/0.0.1/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: "3.20"
+description: A Helm chart for ZITADEL configurator
+icon: https://fabled.se/img/cat_logo.svg
+kubeVersion: ">= 1.21.0-0"
+maintainers:
+  - email: platform@fabled.se
+    name: zitadel-configurator
+    url: https://fabled.se
+name: zitadel-configurator
+type: application
+version: 0.0.1

--- a/charts/auth/zitadel-configurator/0.0.1/templates/_helpers.tpl
+++ b/charts/auth/zitadel-configurator/0.0.1/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{- define "zitadelConfigurator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "zitadelConfigurator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "zitadelConfigurator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "zitadelConfigurator.labels" -}}
+helm.sh/chart: {{ include "zitadelConfigurator.chart" . }}
+{{ include "zitadelConfigurator.selectorLabels" . }}
+app.kubernetes.io/version: {{ default .Values.image.tag .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "zitadelConfigurator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "zitadelConfigurator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "zitadelConfigurator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.enabled }}
+{{- default (include "zitadelConfigurator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "zitadelConfigurator.customDomain" -}}
+  {{- if or (hasPrefix "https://" .Values.zitadelCustomDomain) (hasPrefix "http://" .Values.zitadelCustomDomain) }}
+    {{- quote .Values.zitadelCustomDomain }}
+  {{- else }}
+    {{- quote (printf "https://%s" .Values.zitadelCustomDomain) }}
+  {{- end }}
+{{- end }}

--- a/charts/auth/zitadel-configurator/0.0.1/templates/configmap.yaml
+++ b/charts/auth/zitadel-configurator/0.0.1/templates/configmap.yaml
@@ -1,0 +1,440 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "zitadelConfigurator.fullname" . }}"
+  labels:
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: configurator
+    {{- with .Values.configMap.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  zitadel-configurator: |-
+    #!/bin/sh
+
+    {{ if .Values.job.debug }}
+    DEBUG="true"
+    {{ else }}
+    DEBUG="false"
+    {{ end }}
+
+    apk add --no-cache \
+      curl \
+      jq \
+      openssl \
+      coreutils >/dev/null
+
+    CUSTOM_DOMAIN={{ include "zitadelConfigurator.customDomain" . }}
+
+    # Get the Access Token using the Service Account data
+    SERVICE_ACCOUNT_JSON_PATH="/config/serviceaccount/{{ .Values.zitadelserviceAccountJsonPath }}"
+
+    if [ ! -f "$SERVICE_ACCOUNT_JSON_PATH" ]; then
+      echo "Service account file not found: $SERVICE_ACCOUNT_JSON_PATH"
+      exit 1
+    fi
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Using custom domain: $CUSTOM_DOMAIN"
+      echo "Service account path: $SERVICE_ACCOUNT_JSON_PATH"
+    fi
+
+    echo "Creating Zitadel Personal Access Token..."
+
+    CURRENT_UTC_TIMESTAMP="$(date +%s)"
+    EXPIRATION_UTC_TIMESTAMP="$(($CURRENT_UTC_TIMESTAMP + 864000))" # 10 minutes
+
+    KEY_ID="$(jq -r .keyId <"$SERVICE_ACCOUNT_JSON_PATH")"
+    KEY="$(jq -r .key <"$SERVICE_ACCOUNT_JSON_PATH")"
+    USER_ID="$(jq -r .userId <"$SERVICE_ACCOUNT_JSON_PATH")"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Key ID: $KEY_ID"
+      echo "User ID: $USER_ID"
+      echo "Key: $KEY"
+    fi
+
+    HEADER="$(printf "%s" '{"alg": "RS256", "kid": "'"${KEY_ID}"'", "typ": "JWT"}' | tr -d '\n' | tr -d '\r' | base64 -w 0 | tr +/ -_ | tr -d '=')"
+    PAYLOAD="$(printf "%s" '{"iss": "'"${USER_ID}"'", "sub": "'"${USER_ID}"'", "aud": "'"${CUSTOM_DOMAIN}"'", "iat": '"${CURRENT_UTC_TIMESTAMP}"', "exp": '"${EXPIRATION_UTC_TIMESTAMP}"'}' | tr -d '\n' | tr -d '\r' | base64 -w 0 | tr +/ -_ | tr -d '=')"
+    PAYLOAD_HEADER="$(printf "%s" "$HEADER" "." "$PAYLOAD")"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Header: $(printf "%s" '{"alg": "RS256", "kid": "'"${KEY_ID}"'", "typ": "JWT"}')"
+      echo "Header base64: $HEADER"
+      echo "Payload: $(printf "%s" '{"iss": "'"${USER_ID}"'", "sub": "'"${USER_ID}"'", "aud": "'"${CUSTOM_DOMAIN}"'", "iat": '"${CURRENT_UTC_TIMESTAMP}"', "exp": '"${EXPIRATION_UTC_TIMESTAMP}"'}')"
+      echo "Payload base64: $PAYLOAD"
+      echo "Payload.Header base64: $PAYLOAD_HEADER"
+    fi
+
+    temp_private_key_file="$(mktemp)"
+    printf "%s" "$KEY" >"$temp_private_key_file"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "temp_private_key_file: $temp_private_key_file"
+      echo "temp_private_key_file content: $(cat $temp_private_key_file)"
+    fi
+
+    SIGNATURE="$(printf "%s" "$PAYLOAD_HEADER" | openssl dgst -sign "$temp_private_key_file" | base64 -w 0 | tr +/ -_ | tr -d '=' | tr -d '\n' | tr -d '\r')"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Signature: $SIGNATURE"
+    fi
+
+    rm "$temp_private_key_file"
+
+    JWT_TOKEN="$(printf "%s" "$PAYLOAD_HEADER" "." "$SIGNATURE")"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "JWT token: $JWT_TOKEN"
+    fi
+
+    OAUTH_TOKEN_RESPONSE="""$(
+      curl --silent \
+        --request POST \
+        --url "$CUSTOM_DOMAIN/oauth/v2/token" \
+        --header "Content-Type: application/x-www-form-urlencoded" \
+        --data grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer' \
+        --data scope='openid profile urn:zitadel:iam:org:project:id:zitadel:aud' \
+        --data "assertion=$JWT_TOKEN"
+    )"""
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "$OAUTH_TOKEN_RESPONSE"
+    fi
+
+    ACCESS_TOKEN="$(echo $OAUTH_TOKEN_RESPONSE | jq -r .access_token)"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Access token: $ACCESS_TOKEN"
+    fi
+
+    {{ if .Values.zitadelAction.enabled }}
+    # Create an Action to increment the OIDC response with the user groups
+    data='{
+      "query": {
+        "offset": "0",
+        "limit": 100,
+        "asc": true
+      },
+      "sortingColumn": "ACTION_FIELD_NAME_UNSPECIFIED",
+      "queries": [
+        {
+          "actionNameQuery": {
+            "name": {{ quote .Values.zitadelAction.name }},
+            "method": "TEXT_QUERY_METHOD_EQUALS"
+          }
+        }
+      ]
+    }'
+
+    response="$(
+      curl --silent \
+        --request POST \
+        --url "$CUSTOM_DOMAIN/management/v1/actions/_search" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
+        --header "Authorization: Bearer $ACCESS_TOKEN" \
+        --data "$(echo $data | jq)"
+    )"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "$response"
+    fi
+
+    action_id="$(echo $response | jq 'if .result then .result[0].id else "" end')"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Action ID: $action_id"
+    fi
+
+    if [ -z "$action_id" ] || [ "$action_id" == '""' ]; then
+      echo "Creating Zitadel Action..."
+
+      data='{
+        "name": {{ quote .Values.zitadelAction.name }},
+        "script": {{ .Values.zitadelAction.script | replace "\n" " " | quote }},
+        "timeout": {{ quote .Values.zitadelAction.timeout }},
+        "allowedToFail": {{ .Values.zitadelAction.allowedToFail }}
+      }'
+
+      response="$(
+        curl --silent \
+          --request POST \
+          --url "$CUSTOM_DOMAIN/management/v1/actions" \
+          --header "Content-Type: application/json" \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer $ACCESS_TOKEN" \
+          --data "$(echo $data | jq)"
+      )"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "$response"
+      fi
+
+      action_id="$(echo $response | jq .id)"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "Created action ID: $action_id"
+      fi
+
+      data='{
+        "actionIds": [
+          '"$action_id"'
+        ]
+      }'
+
+      curl --silent \
+        --request POST \
+        --url "$CUSTOM_DOMAIN/management/v1/flows/2/trigger/4" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
+        --header "Authorization: Bearer $ACCESS_TOKEN" \
+        --data "$(echo $data | jq)"
+
+      curl --silent \
+        --request POST \
+        --url "$CUSTOM_DOMAIN/management/v1/flows/2/trigger/5" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
+        --header "Authorization: Bearer $ACCESS_TOKEN" \
+        --data "$(echo $data | jq)"
+    fi
+    {{ end }}
+
+    # Create an Application
+    data='{
+      "query": {
+        "offset": "0",
+        "limit": 100,
+        "asc": true
+      },
+      "queries": [
+        {
+          "nameQuery": {
+            "name": {{ quote .Values.zitadelProject.name }},
+            "method": "TEXT_QUERY_METHOD_EQUALS"
+          }
+        }
+      ]
+    }'
+
+    response="$(
+      curl --silent \
+        --request POST \
+        --url "$CUSTOM_DOMAIN/management/v1/projects/_search" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
+        --header "Authorization: Bearer $ACCESS_TOKEN" \
+        --data "$(echo $data | jq)"
+    )"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "$response"
+    fi
+
+    project_id="$(echo $response | jq -r 'if .result then .result[0].id else "" end')"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Project ID: $project_id"
+    fi
+
+    if [ -z "$project_id" ] || [ "$project_id" == '""' ]; then
+      {{ if .Values.zitadelProject.enabled }}
+      echo "Creating Zitadel Project..."
+
+      data='{
+        "name": {{ quote .Values.zitadelProject.name }},
+        "projectRoleAssertion": {{ .Values.zitadelProject.projectRoleAssertion }},
+        "projectRoleCheck": {{ .Values.zitadelProject.projectRoleCheck }},
+        "hasProjectCheck": {{ .Values.zitadelProject.hasProjectCheck }},
+        "privateLabelingSetting": "PRIVATE_LABELING_SETTING_UNSPECIFIED"
+      }'
+
+      response="$(
+        curl --silent \
+          --request POST \
+          --url "$CUSTOM_DOMAIN/management/v1/projects" \
+          --header "Content-Type: application/json" \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer $ACCESS_TOKEN" \
+          --data "$(echo $data | jq)"
+      )"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "$response"
+      fi
+
+      project_id="$(echo $response | jq -r .id)"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "Created project ID: $project_id"
+      fi
+      {{ end }}
+
+      {{ if .Values.zitadelProjectRoles.enabled }}
+      echo "Creating Zitadel Roles..."
+
+      data='{
+        "roleKey": "{{ .Values.zitadelProjectRoles.prefix }}:admin",
+        "displayName": "{{ .Values.zitadelProjectRoles.prefix }}:admin"
+      }'
+
+      response="$(
+        curl --silent \
+          --request POST \
+          --url "$CUSTOM_DOMAIN/management/v1/projects/$project_id/roles" \
+          --header "Content-Type: application/json" \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer $ACCESS_TOKEN" \
+          --data "$(echo $data | jq)"
+      )"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "$response"
+      fi
+
+      data='{
+        "roleKey": "{{ .Values.zitadelProjectRoles.prefix }}:view",
+        "displayName": "{{ .Values.zitadelProjectRoles.prefix }}:view"
+      }'
+
+      response="$(
+        curl --silent \
+          --request POST \
+          --url "$CUSTOM_DOMAIN/management/v1/projects/$project_id/roles" \
+          --header "Content-Type: application/json" \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer $ACCESS_TOKEN" \
+          --data "$(echo $data | jq)"
+      )"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "$response"
+      fi
+    fi
+    {{ end }}
+
+    {{ if .Values.zitadelApplication.enabled }}
+    echo "Creating Zitadel Application..."
+
+    data='{
+      "query": {
+        "offset": "0",
+        "limit": 100,
+        "asc": true
+      },
+      "queries": [
+        {
+          "nameQuery": {
+            "name": {{ quote .Values.zitadelApplication.name }},
+            "method": "TEXT_QUERY_METHOD_EQUALS"
+          }
+        }
+      ]
+    }'
+
+    response="$(
+      curl --silent \
+        --request POST \
+        --url "$CUSTOM_DOMAIN/management/v1/projects/$project_id/apps/_search" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
+        --header "Authorization: Bearer $ACCESS_TOKEN" \
+        --data "$(echo $data | jq)"
+    )"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "$response"
+    fi
+
+    application_id="$(echo $response | jq -r 'if .result then .result[0].id else "" end')"
+
+    if [ "$DEBUG" == "true" ]; then
+      echo "Application ID: $application_id"
+    fi
+
+    client_id=""
+    client_secret=""
+
+    if [ -z "$application_id" ] || [ "$application_id" == '""' ]; then
+      data='{
+        "name": {{ quote .Values.zitadelApplication.name }},
+        "redirectUris": [
+          {{- range $index, $uri := .Values.zitadelApplication.redirectUris }}
+            {{- if $index }},{{ end }}"{{ $uri }}"
+          {{- end -}}
+        ],
+        "responseTypes": [
+          {{- range $index, $type := .Values.zitadelApplication.responseTypes }}
+            {{- if $index }},{{ end }}"{{ $type }}"
+          {{- end -}}
+        ],
+        "grantTypes": [
+          {{- range $index, $grant := .Values.zitadelApplication.grantTypes }}
+            {{- if $index }},{{ end }}"{{ $grant }}"
+          {{- end -}}
+        ],
+        "appType": {{ quote .Values.zitadelApplication.appType }},
+        "authMethodType": {{ quote .Values.zitadelApplication.authMethodType }},
+        "postLogoutRedirectUris": [
+          {{- range $index, $uri := .Values.zitadelApplication.postLogoutRedirectUris }}
+            {{- if $index }},{{ end }}"{{ $uri }}"
+          {{- end -}}
+        ],
+        "version": {{ quote .Values.zitadelApplication.version }},
+        "devMode": {{ .Values.zitadelApplication.devMode }},
+        "accessTokenType": {{ quote .Values.zitadelApplication.accessTokenType }},
+        "accessTokenRoleAssertion": {{ .Values.zitadelApplication.accessTokenRoleAssertion }},
+        "idTokenRoleAssertion": {{ .Values.zitadelApplication.idTokenRoleAssertion }},
+        "idTokenUserinfoAssertion": {{ .Values.zitadelApplication.idTokenUserinfoAssertion }},
+        "clockSkew": {{ quote .Values.zitadelApplication.clockSkew }},
+        "skipNativeAppSuccessPage": {{ .Values.zitadelApplication.skipNativeAppSuccessPage }}
+      }'
+
+      response="$(
+        curl --silent \
+          --request POST \
+          --url "$CUSTOM_DOMAIN/management/v1/projects/$project_id/apps/oidc" \
+          --header "Content-Type: application/json" \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer $ACCESS_TOKEN" \
+          --data "$(echo $data | jq)"
+      )"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "$response"
+      fi
+
+      client_id="$(echo $response | jq -r .clientId)"
+      client_secret="$(echo $response | jq -r .clientSecret)"
+
+      if [ "$DEBUG" == "true" ]; then
+        echo "Client ID: $client_id"
+        echo "Client Secret: $client_secret"
+      fi
+
+      {{ if .Values.zitadelApplicationSecret.enabled }}
+      # Create Zitadel Application secret with Client ID and Client Secret
+      echo "Creating Zitadel Application Secret..."
+
+      curl -s -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+      chmod +x kubectl
+      mv kubectl /usr/local/bin/kubectl
+
+      kubectl get secrets -n {{ .Release.Namspace | default "auth" }} {{ .Values.zitadelApplicationSecret.name }} >/dev/null
+
+      if [ "$?" == "0" ]; then
+        echo "Secret {{ .Values.zitadelApplicationSecret.name }} already exists in namespace {{ .Release.Namspace | default "auth" }}. Recreating..."
+
+        kubectl delete secret -n {{ .Release.Namspace | default "auth" }} {{ .Values.zitadelApplicationSecret.name }} >/dev/null
+      fi
+
+      kubectl create secret generic {{ .Values.zitadelApplicationSecret.name }} \
+        --namespace {{ .Release.Namspace | default "auth" }} \
+        --from-literal=client_id="$client_id" \
+        --from-literal=client_secret="$client_secret"
+      {{ end }}
+    fi
+    {{ end }}

--- a/charts/auth/zitadel-configurator/0.0.1/templates/job.yaml
+++ b/charts/auth/zitadel-configurator/0.0.1/templates/job.yaml
@@ -1,0 +1,99 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "zitadelConfigurator.fullname" . }}"
+  labels:
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "zitadelConfigurator.fullname" . }}
+    {{- with .Values.job.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "zitadelConfigurator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "zitadelConfigurator.fullname" . }}
+        {{- with .Values.job.podAdditionalLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.job.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "zitadelConfigurator.serviceAccountName" . }}
+      enableServiceLinks: false
+      restartPolicy: OnFailure
+      containers:
+        - name: {{ include "zitadelConfigurator.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 14 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args: ["-c", "/config/script/{{ include "zitadelConfigurator.fullname" . }}"]
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+          - name: {{ .Values.zitadelServiceAccountSecretName }}
+            mountPath: /config/serviceaccount
+            readOnly: true
+          - name: {{ include "zitadelConfigurator.fullname" . }}
+            readOnly: true
+            mountPath: /config/script
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.job.resources | nindent 12 }}
+      {{- if .Values.job.extraContainers }}
+        {{- toYaml .Values.job.extraContainers | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: {{ .Values.zitadelServiceAccountSecretName }}
+        secret:
+          secretName: {{ .Values.zitadelServiceAccountSecretName }}
+          items:
+            - key: {{ .Values.zitadelserviceAccountJsonPath }}
+              path: {{ .Values.zitadelserviceAccountJsonPath }}
+          defaultMode: 0644
+      - name: {{ include "zitadelConfigurator.fullname" . }}
+        configMap: 
+          name: {{ include "zitadelConfigurator.fullname" . }}
+          items:
+            - key: {{ include "zitadelConfigurator.fullname" . }}
+              path: {{ include "zitadelConfigurator.fullname" . }}
+          defaultMode: 0755
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/auth/zitadel-configurator/0.0.1/templates/rbac.yaml
+++ b/charts/auth/zitadel-configurator/0.0.1/templates/rbac.yaml
@@ -1,10 +1,45 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.serviceAccount.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "zitadelConfigurator.serviceAccountName" . }}
+  labels:
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "create", "delete" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "zitadelConfigurator.serviceAccountName" . }}
+  labels:
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name:  {{ include "zitadelConfigurator.serviceAccountName" . }}
+roleRef:
+  kind: Role
+  name: {{ include "zitadelConfigurator.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- if .Values.rbac.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.rbac.namePrefix }}:admin
+  name: {{ .Values.zitadelProjectRoles.prefix }}:admin
   labels:
-    {{- include "dex-k8s-authenticator.labels" . | nindent 4 }}
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,28 +52,28 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.rbac.namePrefix }}:admin
+  name: {{ .Values.zitadelProjectRoles.prefix }}:admin
   labels:
-    {{- include "dex-k8s-authenticator.labels" . | nindent 4 }}
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.rbac.namePrefix }}:admin
+  name: {{ .Values.zitadelProjectRoles.prefix }}:admin
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: Group
-    name: {{ .Values.rbac.namePrefix }}:admin
+    name: {{ .Values.zitadelProjectRoles.prefix }}:admin
     apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.rbac.namePrefix }}:view
+  name: {{ .Values.zitadelProjectRoles.prefix }}:view
   labels:
-    {{- include "dex-k8s-authenticator.labels" . | nindent 4 }}
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -202,19 +237,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.rbac.namePrefix }}:view
+  name: {{ .Values.zitadelProjectRoles.prefix }}:view
   labels:
-    {{- include "dex-k8s-authenticator.labels" . | nindent 4 }}
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.rbac.namePrefix }}:view
+  name: {{ .Values.zitadelProjectRoles.prefix }}:view
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: Group
-    name: {{ .Values.rbac.namePrefix }}:view
+    name: {{ .Values.zitadelProjectRoles.prefix }}:view
     apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/auth/zitadel-configurator/0.0.1/templates/serviceaccount.yaml
+++ b/charts/auth/zitadel-configurator/0.0.1/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "zitadelConfigurator.serviceAccountName" . }}
+  labels:
+    {{- include "zitadelConfigurator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/auth/zitadel-configurator/0.0.1/values.yaml
+++ b/charts/auth/zitadel-configurator/0.0.1/values.yaml
@@ -1,0 +1,137 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: alpine
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+
+zitadelCustomDomain: https://id.demo.ertia.cloud
+
+zitadelServiceAccountSecretName: zitadel-admin-sa
+zitadelserviceAccountJsonPath: zitadel-admin-sa.json
+
+zitadelAction:
+  enabled: true
+  name: groupsClaim
+  script: |
+    function groupsClaim(ctx, api) {
+      if (ctx.v1.user.grants === undefined || ctx.v1.user.grants.count == 0) {
+        return;
+      }
+
+      let grants = [];
+
+      ctx.v1.user.grants.grants.forEach(claim => {
+        claim.roles.forEach(role => {
+          grants.push(role);
+        });
+      });
+
+      api.v1.claims.setClaim('groups', grants);
+    }
+  timeout: 10s
+  allowedToFail: true
+
+zitadelProject:
+  enabled: true
+  name: Kubernetes
+  projectRoleAssertion: true
+  projectRoleCheck: true
+  hasProjectCheck: true
+
+zitadelProjectRoles:
+  enabled: true
+  prefix: oidc
+
+zitadelApplication:
+  enabled: true
+  name: Single Sign-On
+  redirectUris:
+    - https://login.demo.ertia.cloud/callback
+  postLogoutRedirectUris:
+    - https://login.demo.ertia.cloud
+  responseTypes:
+    - OIDC_RESPONSE_TYPE_CODE
+  grantTypes:
+    - OIDC_GRANT_TYPE_AUTHORIZATION_CODE
+    - OIDC_GRANT_TYPE_REFRESH_TOKEN
+  appType: OIDC_APP_TYPE_WEB
+  version: OIDC_VERSION_1_0
+  authMethodType: OIDC_AUTH_METHOD_TYPE_BASIC
+  devMode: false
+  accessTokenType: OIDC_TOKEN_TYPE_BEARER
+  accessTokenRoleAssertion: true
+  idTokenRoleAssertion: true
+  idTokenUserinfoAssertion: true
+  clockSkew: 1s
+  skipNativeAppSuccessPage: true
+
+zitadelApplicationSecret:
+  enabled: true
+  name: zitadel-kubernetes-sso
+
+job:
+  debug: true
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "5"
+  resources: {}
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 100
+  extraContainers: []
+  podAnnotations: {}
+  podAdditionalLabels: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+configMap:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
+
+rbac:
+  enabled: true
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
+
+serviceAccount:
+  enabled: true
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
+  name: ""
+
+apiServerConfig:
+  enabled: true
+  config: |
+    --kube-apiserver-arg=oidc-issuer-url=https://login.demo.ertia.cloud
+    --kube-apiserver-arg=oidc-client-id=$client_id
+    --kube-apiserver-arg=oidc-username-claim=email
+    --kube-apiserver-arg=oidc-groups-claim=groups
+
+extraVolumes: []
+extraVolumeMounts: []
+
+podSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  readOnlyRootFilesystem: false
+  privileged: true


### PR DESCRIPTION
This chart is used to configure Zitadel programmatically for Single Sign-On. It creates a Kubernetes job to execute API calls in Zitadel and create all the required configuration automatically.

It's a first and "quick" attempt to have it programmatically. In the future, it is worth to move from Shell script to a proper language as Go and have it as an application.

It could be seen as an embryo Zitadel operator.